### PR TITLE
Put NBTTagEnd into classCache

### DIFF
--- a/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
+++ b/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
@@ -52,6 +52,7 @@ public final class NBTEditor {
 				classCache.put( "NBTBase", Class.forName( "net.minecraft.server." + VERSION + "." + "NBTBase" ) );
 				classCache.put( "NBTTagCompound", Class.forName( "net.minecraft.server." + VERSION + "." + "NBTTagCompound" ) );
 				classCache.put( "NBTTagList", Class.forName( "net.minecraft.server." + VERSION + "." + "NBTTagList" ) );
+				classCache.put( "NBTTagEnd", Class.forName( "net.minecraft.server." + VERSION + "." + "NBTTagEnd" ) );
 				classCache.put( "MojangsonParser", Class.forName( "net.minecraft.server." + VERSION + "." + "MojangsonParser" ) );
 	
 				classCache.put( "ItemStack", Class.forName( "net.minecraft.server." + VERSION + "." + "ItemStack" ) );
@@ -72,6 +73,7 @@ public final class NBTEditor {
 				classCache.put( "NBTBase", Class.forName( "net.minecraft.nbt.NBTBase" ) );
 				classCache.put( "NBTTagCompound", Class.forName( "net.minecraft.nbt.NBTTagCompound" ) );
 				classCache.put( "NBTTagList", Class.forName( "net.minecraft.nbt.NBTTagList" ) );
+				classCache.put( "NBTTagEnd", Class.forName( "net.minecraft.nbt.NBTTagEnd" ) );
 				classCache.put( "MojangsonParser", Class.forName( "net.minecraft.nbt.MojangsonParser" ) );
 				
 				classCache.put( "ItemStack", Class.forName( "net.minecraft.world.item.ItemStack" ) );


### PR DESCRIPTION
On 1.17, since NBTTagEnd is not put into classCache, NBTEditor tries to find it with the path `net.minecraft.server.v1_17_R1.NBTTagEnd` which is incorrect. This PR does just that.