### PR TITLE
Out of range TagList access should return null instead of throwing errors

### DIFF
--- a/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
+++ b/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
@@ -180,7 +180,11 @@ public final class NBTEditor {
 				methodCache.put( "getKeys", getNMSClass( "NBTTagCompound" ).getMethod( "d" ) );
 			}
 
-			if ( LOCAL_VERSION.greaterThanOrEqualTo( MinecraftVersion.v1_18 ) ) {
+			if ( LOCAL_VERSION.greaterThanOrEqualTo( MinecraftVersion.v1_18_2 ) ) {
+				methodCache.put( "hasTag", getNMSClass( "ItemStack" ).getMethod( "s" ) );
+				methodCache.put( "getTag", getNMSClass( "ItemStack" ).getMethod( "t" ) );
+				methodCache.put( "setTag", getNMSClass( "ItemStack" ).getMethod( "c", getNMSClass( "NBTTagCompound" ) ) );
+			} else if ( LOCAL_VERSION.greaterThanOrEqualTo( MinecraftVersion.v1_18 ) ) {
 				methodCache.put( "hasTag", getNMSClass( "ItemStack" ).getMethod( "r" ) );
 				methodCache.put( "getTag", getNMSClass( "ItemStack" ).getMethod( "s" ) );
 				methodCache.put( "setTag", getNMSClass( "ItemStack" ).getMethod( "c", getNMSClass( "NBTTagCompound" ) ) );
@@ -1515,8 +1519,9 @@ public final class NBTEditor {
 		v1_15( "1_15", 7 ),
 		v1_16( "1_16", 8 ),
 		v1_17( "1_17", 9 ),
-		v1_18( "1_18", 10 ),
-		v1_19( "1_19", 11 );
+		v1_18( "1_18_R1", 10 ),
+		v1_18_2( "1_18_R2", 11 ),
+		v1_19( "1_19", 12 );
 
 		private int order;
 		private String key;

--- a/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
+++ b/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
@@ -1402,7 +1402,13 @@ public final class NBTEditor {
 			} else if ( getNMSClass( "NBTTagCompound" ).isInstance( notCompound ) ) {
 				notCompound = getMethod( "get" ).invoke( notCompound, ( String ) key );
 			} else if ( getNMSClass( "NBTTagList" ).isInstance( notCompound ) ) {
-				notCompound = ( ( List< ? > ) NBTListData.get( notCompound ) ).get( ( int ) key );
+				int keyIndex = ( int ) key;
+				List< ? > tagList = ( List< ? > ) NBTListData.get( notCompound );
+				if ( keyIndex >= 0 && keyIndex < tagList.size() ) {
+					notCompound = tagList.get( keyIndex );
+				} else {
+					notCompound = null;
+				}
 			} else {
 				return getNBTVar( notCompound );
 			}

--- a/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
+++ b/src/main/java/io/github/bananapuncher714/nbteditor/NBTEditor.java
@@ -1303,7 +1303,13 @@ public final class NBTEditor {
 			Object key = keys[ index ];
 			Object oldCompound = compound;
 			if ( key instanceof Integer ) {
-				compound = ( ( List< ? > ) NBTListData.get( compound ) ).get( ( int ) key );
+				int keyIndex = ( int ) key;
+				List< ? > tagList = ( List< ? > ) NBTListData.get( compound );
+				if ( keyIndex >= 0 && keyIndex < tagList.size() ) {
+					compound = tagList.get( keyIndex );
+				} else {
+					compound = null;
+				}
 			} else if ( key != null ) {
 				compound = getMethod( "get" ).invoke( compound, ( String ) key );
 			}
@@ -1371,7 +1377,13 @@ public final class NBTEditor {
 			} else if ( getNMSClass( "NBTTagCompound" ).isInstance( compound ) ) {
 				compound = getMethod( "get" ).invoke( compound, ( String ) key );
 			} else if ( getNMSClass( "NBTTagList" ).isInstance( compound ) ) {
-				compound = ( ( List< ? > ) NBTListData.get( compound ) ).get( ( int ) key );
+				int keyIndex = ( int ) key;
+				List< ? > tagList = ( List< ? > ) NBTListData.get( compound );
+				if ( keyIndex >= 0 && keyIndex < tagList.size() ) {
+					compound = tagList.get( keyIndex );
+				} else {
+					compound = null;
+				}
 			}
 		}
 		return new NBTCompound( compound );


### PR DESCRIPTION
This PR adds a range check before accessing tag lists. In the documentation, methods are clearly stated that the target object "or **null if none is stored at the provided location**". Therefore if an item at index in a tag list does not exist, null should be returned instead of an out of bound exception.

*Side note: Are variables named "n**o**tCompound" throughout different methods typos of "nbtCompound", or is it intentional?*